### PR TITLE
Use Docker-compose and make container stateless

### DIFF
--- a/extra/docker/Dockerfile
+++ b/extra/docker/Dockerfile
@@ -7,11 +7,10 @@ RUN set -x; \
         mkdir -p /mnt/host && \
         chown -R koozic /mnt/host
 
-# Reconfigure locales so PostgreSQL uses UTF-8 encoding
+# Reconfigure locales to use UTF-8 encoding
 RUN set -x; \
         apt-get update -qq && \
-        apt-get install -y --no-install-recommends -qq locales && \
-        apt-get clean -qq
+        apt-get install -y --no-install-recommends -qq locales
 RUN set -x; \
         dpkg-reconfigure -fnoninteractive locales && \
         sed -i 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/g' /etc/locale.gen && \
@@ -28,8 +27,6 @@ RUN set -x; \
             lsb-base \
             mediainfo \
             node-less \
-            postgresql \
-            postgresql-client \
             python3-babel \
             python3-dateutil \
             python3-decorator \
@@ -70,7 +67,8 @@ RUN set -x; \
 RUN set -x; \
         pip3 install \
             mutagen==1.40.0 \
-            pytaglib==1.4.1
+            pytaglib==1.4.1 \
+            num2words
 
 # Install KooZic
 RUN set -x; \
@@ -82,14 +80,6 @@ RUN set -x; \
         tar xfz koozic/extra/ffmpeg/ffmpeg-3.4-64bit.tar.gz -C /usr/local/bin && \
         mv koozic /usr/local/ && \
         chown -R koozic /usr/local/koozic
-
-# Set up PostgreSQL and KooZic
-RUN set -x; \
-        sed -i 's/5432/54321/g' /etc/postgresql/9.6/main/postgresql.conf && \
-        service postgresql start && \
-        sleep 5 && \
-        su - postgres -c "createuser -s koozic" && \
-        su - koozic -c "/usr/local/koozic/odoo-bin -d koozic --db_port=54321 -i oomusic,oovideo --without-demo=all --stop-after-init --log-level=warn"
 
 # Copy entrypoint script
 COPY ./entrypoint.sh /

--- a/extra/docker/README.md
+++ b/extra/docker/README.md
@@ -1,33 +1,24 @@
-This folder provides a basic Docker configuration file in order to run a fully functional KooZic
+This folder provides a basic Docker configuration using Docker-compose in order to run a fully functional KooZic
 installation. It includes:
 - Debian 9
-- KooZic 1.0.0
-- PostgreSQL 9.6
+- KooZic 1.1.0
 - FFmpeg 3.4
+- PostgreSQL from Docker hub
 
-By default, it is configured to take advantage of multi-processing. The container runs its own
-PostgreSQL server on port 54321. Therefore, the latter should be available on your host system.
-
-# Set up the container
+# Set up containers
 
 1. Install Docker following the
 [official instructions](https://docs.docker.com/engine/installation/)
 2. Build:
 ```
-docker build -t koozic .
+docker-compose build
 ```
-3. Run:
+3. Configure:
+Edit `docker-compose.yml` and replace `/music` by the music folder you want to share.
+4. Run:
 ```
-docker run -d -p 8069:8069 -p 8072:8072 -v <host_folder>:/mnt/host:ro --name koozic koozic
+docker-compose up -d
 ```
-Replace `<host_folder>` by the music folder you want to share. It will be available in `/mnt/host`
-inside the container. KooZic should now be available at
-[http://localhost:8069](http://localhost:8069).
 
-# Execute the container
-
-The usual Docker instructions can be used to start and stop the container:
-```
-docker start koozic
-docker stop koozic
-```
+KooZic should now be available at [http://localhost:8069](http://localhost:8069).
+Don't forget to add `/mnt/host` in the Folders section.

--- a/extra/docker/docker-compose.yml
+++ b/extra/docker/docker-compose.yml
@@ -1,0 +1,32 @@
+version: '3.7'
+
+services:
+
+  app:
+    container_name: koozic_app
+    restart: always
+    build: .
+    image: koozic_app:latest
+    volumes:
+      - koozic_app:/home/koozic/.local
+      - /music:/mnt/host:ro
+    depends_on:
+      - db
+    ports:
+      - 8069:8069
+      - 8072:8072
+
+  db:
+    container_name: koozic_db
+    restart: always
+    image: postgres:latest
+    volumes:
+      - koozic_db:/var/lib/postgresql
+    environment:
+      - POSTGRES_USER=koozic
+      - POSTGRES_PASSWORD=koozic
+      - POSTGRES_DB=koozic
+
+volumes:
+  koozic_app:
+  koozic_db:

--- a/extra/docker/entrypoint.sh
+++ b/extra/docker/entrypoint.sh
@@ -1,9 +1,22 @@
 #!/bin/bash
 
-set -e
-
-service postgresql restart
+# Wait for Postgres to be up
 sleep 5
-su - koozic -c "/usr/local/koozic/odoo-bin --workers=4 --limit-time-cpu=1800 --limit-time-real=3600 --db_port=54321 --without-demo=all --no-database-list --log-level=warn"
 
-exit 1
+# Give to koozic user the right to write in app volume
+chown -R koozic /home/koozic/.local
+
+# Initialize db (odoo automatically detects if db is already initialized)
+echo "Initializing db..."
+su - koozic -c "/usr/local/koozic/odoo-bin -d koozic \
+			--db_host=db --db_port=5432 \
+			--db_user=koozic --db_password=koozic \
+			-i oomusic,oovideo --without-demo=all --stop-after-init --log-level=warn"
+echo "db initialization done"
+
+# Start koozic
+su - koozic -c "/usr/local/koozic/odoo-bin \
+	--workers=4 --limit-time-cpu=1800 --limit-time-real=3600 \
+	--db_host=db --db_port=5432 \
+	--db_user=koozic --db_password=koozic \
+	--without-demo=all --no-database-list --log-level=warn"


### PR DESCRIPTION
Docker container should be stateless to prevent data loss on update.
- Provide docker-compose:
  - Use official Postgres container
  - Store data in volumes
- Minor: add num2words to pip install (to suppress warning from odoo)
- Db initialization should be made at each startup (odoo automatically detects if db is already initialized and update it if needed)